### PR TITLE
fix(reducer): state.activeScreenArray is not an array 

### DIFF
--- a/src/reducer.js
+++ b/src/reducer.js
@@ -157,8 +157,8 @@ const reducer = (state = null, action) => {
         const modals = state.modals;
         const overlays = state.overlays;
         let newActiveScreen = createActiveScreenArray(root, action.payload.componentId);
-        if(!modals.length && !overlays.length && !newActiveScreen) {
-          newActiveScreen = [...state.activeScreenArray];
+        if (!modals.length && !overlays.length && !newActiveScreen) {
+          newActiveScreen = state && state.activeScreenArray && state.activeScreenArray.length ? [...state.activeScreenArray] : [];
         }
         if (!newActiveScreen && modals.length) {
           let i = 0;


### PR DESCRIPTION
**Short description**

sometimes state.activeScreenArray turns out to be a not iterable type so that one cannot use array spread syntax on it.

error:
invalid attempt to spread non-iterable instance

**Proposed changes**
 check state.activeScreenArray whether it is not an array, and if so return empty array